### PR TITLE
Fix status buttons not showing up in some languages

### DIFF
--- a/Main Refresh UI/Refresh Header/Compact Profile Button/Profile Buttons in Account Menu.js
+++ b/Main Refresh UI/Refresh Header/Compact Profile Button/Profile Buttons in Account Menu.js
@@ -419,7 +419,7 @@ class SteamProfileEnhancer {
     const buttons = document.querySelectorAll(CONFIG.selectors.buttonClass)
 
     if (!mainContainer || !buttons.length) return false
-
+    
     this.elements = {
       mainContainer,
       templateButton: buttons[0],
@@ -517,6 +517,7 @@ class SteamProfileEnhancer {
 
     const statusBtns = statuses.map(({ key, url }) => {
       const btn = this.elements.templateButton.cloneNode(true)
+      btn.style.display = "flex";
       btn.textContent = this.t(key)
       btn.classList.add("steam-status-option")
       btn.addEventListener("click", (e) => {


### PR DESCRIPTION
In some languages, like Portuguese, Brazilian Portuguese and Italian (likely many others), the status buttons weren't showing up in the profile dropdown. That happened due to the template button having `display: none` set at the beginning and being cloned without having that setting changed.